### PR TITLE
GFS Precip Rate Differencing

### DIFF
--- a/core/dateMod.py
+++ b/core/dateMod.py
@@ -470,6 +470,18 @@ def find_gfs_neighbors(input_forcings,ConfigOptions,dCurrent,MpiConfg):
         print(tmpFile2)
         print('YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY')
 
+    # If needed, initialize the globalPcpRate1 array (this is for when we have the initial grid, or we need to change
+    # grids.
+    if np.any(input_forcings.globalPcpRate2) and not np.any(input_forcings.globalPcpRate1):
+        input_forcings.globalPcpRate1 = np.empty([input_forcings.globalPcpRate2.shape[0],
+                                                  input_forcings.globalPcpRate2.shape[1]], np.float32)
+    if np.any(input_forcings.globalPcpRate2) and np.any(input_forcings.globalPcpRate1):
+        if input_forcings.globalPcpRate2.shape[0] != input_forcings.globalPcpRate1.shape[0]:
+            # The grid has changed, we need to re-initialize the globalPcpRate1 array.
+            input_forcings.globalPcpRate1 = None
+            input_forcings.globalPcpRate1 = np.empty([input_forcings.globalPcpRate2.shape[0],
+                                                      input_forcings.globalPcpRate2.shape[1]], np.float32)
+
     # Check to see if files are already set. If not, then reset, grids and
     # regridding objects to communicate things need to be re-established.
     if input_forcings.file_in1 != tmpFile1 or input_forcings.file_in2 != tmpFile2:

--- a/core/dateMod.py
+++ b/core/dateMod.py
@@ -491,14 +491,21 @@ def find_gfs_neighbors(input_forcings,ConfigOptions,dCurrent,MpiConfg):
                 input_forcings.rstFlag = 1
                 input_forcings.regridded_forcings1 = input_forcings.regridded_forcings1
                 input_forcings.regridded_forcings2 = input_forcings.regridded_forcings2
+                if input_forcings.productName == "GFS_Production_GRIB2":
+                    if MpiConfg.rank == 0:
+                        input_forcings.globalPcpRate1 = input_forcings.globalPcpRate1
+                        input_forcings.globalPcpRate2 = input_forcings.globalPcpRate2
                 input_forcings.file_in2 = tmpFile1
                 input_forcings.file_in1 = tmpFile1
                 input_forcings.fcst_date2 = input_forcings.fcst_date1
                 input_forcings.fcst_hour2 = input_forcings.fcst_hour1
             else:
-                # The GFS window has shifted. Reset fields 2 to
+                # The forcing window has shifted. Reset fields 2 to
                 # be fields 1.
                 input_forcings.regridded_forcings1[:, :, :] = input_forcings.regridded_forcings2[:, :, :]
+                if input_forcings.productName == "GFS_Production_GRIB2":
+                    if MpiConfg.rank == 0:
+                        input_forcings.globalPcpRate1[:, :] = input_forcings.globalPcpRate2[:, :]
                 input_forcings.file_in1 = tmpFile1
                 input_forcings.file_in2 = tmpFile2
         input_forcings.regridComplete = False

--- a/core/forcingInputMod.py
+++ b/core/forcingInputMod.py
@@ -70,6 +70,8 @@ class input_forcings:
         # --------------------------------
         self.regridded_forcings1 = None
         self.regridded_forcings2 = None
+        self.globalPcpRate1 = None
+        self.globalPcpRate2 = None
         self.regridded_mask = None
         self.final_forcings = None
         self.ndv = None

--- a/core/timeInterpMod.py
+++ b/core/timeInterpMod.py
@@ -247,5 +247,9 @@ def gfs_pcp_time_interp(input_forcings,ConfigOptions,MpiConfig):
             total1 = None
             total2 = None
     # Return the interpolated grid back to the regridding program.
+
+    # Set any negative values to 0.0
+    instPcpGlobal[np.where(instPcpGlobal < 0.0)] = 0.0
+
     return instPcpGlobal
 


### PR DESCRIPTION
Put in logic to handle the asinine way GFS places their precipitation rates into the operational sfc flux GRIB2 files. Logic will use previous avg window to calculate an instantaneous precipitation rate. These are then regridded and interpolated for processing. 