### PR TITLE
GRIB-to-netCDF optimization

### DIFF
--- a/core/forcingInputMod.py
+++ b/core/forcingInputMod.py
@@ -328,7 +328,10 @@ class input_forcings:
             12: None,
             13: None,
             14: None,
-            15: None
+            15: None,
+            16: None,
+            17: None,
+            18: None
         }
         self.grib_mes_idx = grib_message_idx[self.keyValue] 
 

--- a/core/forecastMod.py
+++ b/core/forecastMod.py
@@ -40,8 +40,8 @@ def process_forecasts(ConfigOptions, wrfHydroGeoMeta, inputForcingMod, suppPcpMo
         )
         fcstCycleOutDir = ConfigOptions.output_dir + "/" + \
             ConfigOptions.current_fcst_cycle.strftime('%Y%m%d%H')
-        completeFlag = ConfigOptions.scratch_dir + "/WrfHydroForcing.COMPLETE"
-        #completeFlag = fcstCycleOutDir + "/WrfHydroForcing.COMPLETE"
+        # completeFlag = ConfigOptions.scratch_dir + "/WrfHydroForcing.COMPLETE"
+        completeFlag = fcstCycleOutDir + "/WrfHydroForcing.COMPLETE"
         if os.path.isfile(completeFlag):
             ConfigOptions.statusMsg = "Forecast Cycle: " + \
                                       ConfigOptions.current_fcst_cycle.strftime('%Y-%m-%d %H:%M') + \
@@ -64,8 +64,8 @@ def process_forecasts(ConfigOptions, wrfHydroGeoMeta, inputForcingMod, suppPcpMo
 
         # Compose a path to a log file, which will contain information
         # about this forecast cycle.
-        #ConfigOptions.logFile = fcstCycleOutDir + "/LOG_" + \
-        ConfigOptions.logFile = ConfigOptions.scratch_dir + "/LOG_" + \
+        # ConfigOptions.logFile = ConfigOptions.scratch_dir + "/LOG_" + \
+        ConfigOptions.logFile = ConfigOptions.output_dir + "/LOG_" + \
             ConfigOptions.d_program_init.strftime('%Y%m%d%H%M') + \
             "_" + ConfigOptions.current_fcst_cycle.strftime('%Y%m%d%H%M')
 

--- a/core/ioMod.py
+++ b/core/ioMod.py
@@ -542,7 +542,7 @@ def open_grib2(GribFileIn,NetCdfFileOut,Wgrib2Cmd,ConfigOptions,MpiConfig,
                 idTmp = None
                 pass
 
-        if idTmp is not None:
+        if idTmp is not None and inputVar is not None:
             # Loop through all the expected variables.
             if inputVar not in idTmp.variables.keys():
                 ConfigOptions.errMsg = "Unable to locate expected variable: " + \

--- a/core/suppPrecipMod.py
+++ b/core/suppPrecipMod.py
@@ -63,6 +63,12 @@ class supplemental_precip:
         self.grib_vars = None
         self.tmpFile = None
 
+        self.global_x_lower = None
+        self.global_y_lower = None
+        self.global_x_upper = None
+        self.global_y_upper = None
+        self.has_cache = False
+
     def define_product(self):
         """
         Function to define the product name based on the mapping


### PR DESCRIPTION
Instead of creating a new temporary NetCDF file for each GRIB input field, convert them all in one call to `wgrib2` and then leave the resulting netCDF file open while looping over all the input fields. This change has been added to all the CONUS-level regridders (HRRR, RAP, CFSv2, and GFS). This results in an approximately 30% speed-up vs. the previous method.