### PR TITLE
Correct parameter order in check_regrid_status() calls

### DIFF
--- a/core/parallel.py
+++ b/core/parallel.py
@@ -64,8 +64,8 @@ class MpiConfig:
         return tmp_dict['varTmp']
 
     def scatter_array(self, geoMeta, array_broadcast, ConfigOptions):
-        #return scatter_array_logan(self, geoMeta, array_broadcast, ConfigOptions)
-        return scatter_array_scatterv_no_cache(self, geoMeta, arrayOptions, ConfigOptions)
+        return self.scatter_array_logan(geoMeta, array_broadcast, ConfigOptions)
+        # return self.scatter_array_scatterv_no_cache(geoMeta, array_broadcast, ConfigOptions)
 
     def scatter_array_logan(self, geoMeta, array_broadcast, ConfigOptions):
         """
@@ -208,6 +208,6 @@ class MpiConfig:
             err_handler.log_critical(ConfigOptions, MpiConfig)
             return None
 
-        subarray = np.reshape(recvbuf,[y_upper[self.rank] -y_lower[self.rank],x_upper[self.rank]- x_lower[self.rank]])
+        subarray = np.reshape(recvbuf,[y_upper[self.rank] -y_lower[self.rank],x_upper[self.rank]- x_lower[self.rank]]).copy()
         return subarray
 

--- a/core/regrid.py
+++ b/core/regrid.py
@@ -296,7 +296,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                               config_options, mpi_config, inputVar=None)
     err_handler.check_program_status(config_options, mpi_config)
 
-    for force_count, grib_var in input_forcings.grib_vars:
+    for force_count, grib_var in enumerate(input_forcings.grib_vars):
         if mpi_config.rank == 0:
             config_options.statusMsg = "Processing Conus RAP Variable: " + grib_var
             err_handler.log_msg(config_options, mpi_config)
@@ -537,7 +537,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
             err_handler.log_msg(config_options, mpi_config)
 
         calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
-                                               config_options, mpi_config, wrf_hydro_geo_meta)
+                                               config_options, wrf_hydro_geo_meta, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         if calc_regrid_flag:

--- a/core/regrid.py
+++ b/core/regrid.py
@@ -77,7 +77,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             err_handler.log_msg(config_options, mpi_config)
 
         calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
-                                               config_options, mpi_config, wrf_hydro_geo_meta)
+                                               config_options, wrf_hydro_geo_meta, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         if calc_regrid_flag:
@@ -302,7 +302,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
             err_handler.log_msg(config_options, mpi_config)
 
         calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
-                                               config_options, mpi_config, wrf_hydro_geo_meta)
+                                               config_options, wrf_hydro_geo_meta, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         if calc_regrid_flag:
@@ -778,7 +778,7 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
                                        nc_var
             err_handler.log_msg(config_options, mpi_config)
         calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
-                                               config_options, mpi_config, wrf_hydro_geo_meta)
+                                               config_options, wrf_hydro_geo_meta, mpi_config)
 
         if calc_regrid_flag:
             calculate_weights(mpi_config, config_options,
@@ -1477,7 +1477,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
 
     # Check to see if we need to calculate regridding weights.
     calc_regrid_flag = check_supp_pcp_regrid_status(id_mrms, supplemental_precip, config_options,
-                                                    mpi_config, wrf_hydro_geo_meta)
+                                                    wrf_hydro_geo_meta, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     if calc_regrid_flag:
@@ -1937,7 +1937,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(supplemental_precip, config_options, wrf_hy
 
     # Check to see if we need to calculate regridding weights.
     calc_regrid_flag = check_supp_pcp_regrid_status(id_tmp, supplemental_precip, config_options,
-                                                    mpi_config, wrf_hydro_geo_meta)
+                                                    wrf_hydro_geo_meta, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     if calc_regrid_flag:
@@ -2081,7 +2081,7 @@ def check_regrid_status(id_tmp, force_count, input_forcings, config_options, wrf
     return calc_regrid_flag
 
 
-def check_supp_pcp_regrid_status(id_tmp, supplemental_precip, config_options, mpi_config, wrf_hydro_geo_meta):
+def check_supp_pcp_regrid_status(id_tmp, supplemental_precip, config_options, wrf_hydro_geo_meta, mpi_config):
     """
     Function for checking to see if regridding weights need to be
     calculated (or recalculated).

--- a/core/time_handling.py
+++ b/core/time_handling.py
@@ -40,7 +40,7 @@ def calculate_lookback_window(config_options):
     # beginning of the processing window.
     dt_tmp = d_current_utc - config_options.b_date_proc
     n_fcst_steps = math.floor((dt_tmp.days*1440+dt_tmp.seconds/60.0) / config_options.fcst_freq)
-    config_options.n_fcsts = int(n_fcst_steps) + 1
+    config_options.n_fcsts = int(n_fcst_steps)
     config_options.e_date_proc = config_options.b_date_proc + datetime.timedelta(
         seconds=n_fcst_steps * config_options.fcst_freq * 60)
 


### PR DESCRIPTION
Some calls to check_regrid_status() had the wrong parameter order. This PR should make them all consistent.

Also, this removes an unnecessary / incorrect "+1" when calculating `nFcsts`