### PR TITLE
Change time dimensions to unlimited

### DIFF
--- a/core/ioMod.py
+++ b/core/ioMod.py
@@ -87,7 +87,7 @@ class OutputObj:
 
                 # Create dimensions.
                 try:
-                    idOut.createDimension("time",1)
+                    idOut.createDimension("time", None)
                 except:
                     ConfigOptions.errMsg = "Unable to create time dimension in: " + self.outPath
                     err_handler.log_critical(ConfigOptions, MpiConfig)
@@ -105,7 +105,7 @@ class OutputObj:
                     err_handler.log_critical(ConfigOptions, MpiConfig)
                     break
                 try:
-                    idOut.createDimension("reference_time",1)
+                    idOut.createDimension("reference_time", None)
                 except:
                     ConfigOptions.errMsg = "Unable to create reference_time dimension in: " + self.outPath
                     err_handler.log_critical(ConfigOptions, MpiConfig)


### PR DESCRIPTION
Just following up on Issue #35.

This is a two line change from `1`->`None` for time dimensions.  This sets those dims to "unlimited" allowing for file concatenation and general ease of use.

It'd be a "nice to have," but does introduce changes to the files and low priority.