### PR TITLE
Add shebang for python3.

### DIFF
--- a/genForcing.py
+++ b/genForcing.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import os
 


### PR DESCRIPTION
When executing
```
$ ./genForcing.py --help
```
instead of:
```
$ python genForcing.py --help
```
my shell (zsh) will freeze and I have to terminate it.

Adding the shebang made the help message appear.