### PR TITLE
Minor bugfix to WSPD bias correction

### DIFF
--- a/core/bias_correction.py
+++ b/core/bias_correction.py
@@ -235,8 +235,34 @@ def ncar_blanket_adjustment_lw(input_forcings, config_options, mpi_config, force
                                    input_forcings.productName
         err_handler.log_msg(config_options, mpi_config)
 
-    # Establish blanket adjustment to apply across the board in W/m^2
-    adj_lw = 9.0
+    date_current = config_options.current_output_date
+    hh = float(date_current.hour)
+    MM= float(date_current.month)
+
+    # determine if we're in AnA or SR configuration
+    if config_options.ana_flag == 1:
+        net_bias_AA = 6.84
+        diurnal_ampl_AA = -1.59
+        diurnal_offs_AA = -1.2
+        monthly_ampl_AA = 0.0
+        monthly_offs_AA = 0.0
+
+        adj_lw = net_bias_AA + diurnal_ampl_AA * math.sin(diurnal_offs_AA + hh / 24 * 2 * math.pi) + \
+                    monthly_ampl_AA * math.sin(monthly_offs_AA + MM / 12 * 2*math.pi)
+
+    else:
+        net_bias_SR = 7.12
+        diurnal_ampl_SR = -2.23
+        diurnal_offs_SR = -0.3
+        monthly_ampl_SR = 0.0
+        monthly_offs_SR = 0.0
+        fhr_mult_SR = -0.03
+
+        fhr = config_options.current_output_step
+
+        adj_lw = net_bias_SR + fhr * fhr_mult_SR + \
+                    diurnal_ampl_SR * math.sin(diurnal_offs_SR + hh / 24 * 2*math.pi) + \
+                    monthly_ampl_SR * math.sin(monthly_offs_SR + MM / 12 * 2*math.pi)
 
     # Perform adjustment.
     lw_tmp = None
@@ -298,8 +324,13 @@ def ncar_sw_hrrr_bias_correct(input_forcings, geo_meta_wrf_hydro, config_options
         err_handler.log_msg(config_options, mpi_config)
 
     # Establish constant parameters. NOTE!!! - These will change with future HRRR upgrades.
-    c1 = -0.159
-    c2 = -0.077
+    # determine if we're in AnA or SR configuration
+    if config_options.ana_flag == 1:
+        c1 = 0.079
+        c2 = 0
+    else:
+        c1 = -0.032
+        c2 = -0.040
 
     # Establish current datetime information, along wth solar constants.
     f_hr = input_forcings.fcst_hour2
@@ -411,22 +442,22 @@ def ncar_temp_hrrr_bias_correct(input_forcings, config_options, mpi_config, forc
 
     # determine if we're in AnA or SR configuration
     if config_options.ana_flag == 1:
-        net_bias_AA = 0.13
-        diurnal_ampl_AA = -0.18
-        diurnal_offs_AA = 2.2
-        monthly_ampl_AA = -0.15
-        monthly_offs_AA = -2.0
+        net_bias_AA = 0.019
+        diurnal_ampl_AA = -0.06
+        diurnal_offs_AA = 1.5
+        monthly_ampl_AA = 0.0
+        monthly_offs_AA = 0.0
 
         bias_corr = net_bias_AA + diurnal_ampl_AA * math.sin(diurnal_offs_AA + hh / 24 * 2 * math.pi) + \
                     monthly_ampl_AA * math.sin(monthly_offs_AA + MM / 12 * 2*math.pi)
 
     else:
-        net_bias_SR = 0.060
-        diurnal_ampl_SR = -0.31
-        diurnal_offs_SR = 2.2
-        monthly_ampl_SR = -0.21
-        monthly_offs_SR = -2.4
-        fhr_mult_SR = -0.016
+        net_bias_SR = 0.018
+        diurnal_ampl_SR = -0.06
+        diurnal_offs_SR = -0.6
+        monthly_ampl_SR = 0.0
+        monthly_offs_SR = 0.0
+        fhr_mult_SR = -0.01
 
         fhr = config_options.current_output_step
 
@@ -611,12 +642,29 @@ def ncar_wspd_hrrr_bias_correct(input_forcings, config_options, mpi_config, forc
     wdir = np.arctan2(vgrid_in, ugrid_in)
     wspd = np.sqrt(np.square(ugrid_in) + np.square(vgrid_in))
 
-    if config_options.ana_flag:
-        wspd_bias_corr = 0.35       # fixed for AnA
+    # determine if we're in AnA or SR configuration
+    if config_options.ana_flag == 1:
+        net_bias_AA = 0.23
+        diurnal_ampl_AA = -0.13
+        diurnal_offs_AA = -0.6
+        monthly_ampl_AA = 0.0
+        monthly_offs_AA = 0.0
+
+        bias_corr = net_bias_AA + diurnal_ampl_AA * math.sin(diurnal_offs_AA + hh / 24 * 2 * math.pi) + \
+                    monthly_ampl_AA * math.sin(monthly_offs_AA + MM / 12 * 2*math.pi)
     else:
-        wspd_net_bias_sr = [0.18, 0.15, 0.13, 0.12, 0.11, 0.10, 0.08, 0.07, 0.06, 0.05,
-                            0.03, 0.02, 0.01, -0.01, -0.02, -0.03, -0.04, -0.05]
-        wspd_bias_corr = wspd_net_bias_sr[config_options.current_output_step - 1]
+        net_bias_SR = -0.03
+        diurnal_ampl_SR = -0.15
+        diurnal_offs_SR = -0.3
+        monthly_ampl_SR = 0.0
+        monthly_offs_SR = 0.0
+        fhr_mult_SR = -0.007
+
+        fhr = config_options.current_output_step
+
+        bias_corr = net_bias_SR + fhr * fhr_mult_SR + \
+                    diurnal_ampl_SR * math.sin(diurnal_offs_SR + hh / 24 * 2*math.pi) + \
+                    monthly_ampl_SR * math.sin(monthly_offs_SR + MM / 12 * 2*math.pi)
 
     wspd = wspd + wspd_bias_corr
     wspd = np.where(wspd < 0, 0, wspd)

--- a/core/bias_correction.py
+++ b/core/bias_correction.py
@@ -650,7 +650,7 @@ def ncar_wspd_hrrr_bias_correct(input_forcings, config_options, mpi_config, forc
         monthly_ampl_AA = 0.0
         monthly_offs_AA = 0.0
 
-        bias_corr = net_bias_AA + diurnal_ampl_AA * math.sin(diurnal_offs_AA + hh / 24 * 2 * math.pi) + \
+        wspd_bias_corr = net_bias_AA + diurnal_ampl_AA * math.sin(diurnal_offs_AA + hh / 24 * 2 * math.pi) + \
                     monthly_ampl_AA * math.sin(monthly_offs_AA + MM / 12 * 2*math.pi)
     else:
         net_bias_SR = -0.03
@@ -662,7 +662,7 @@ def ncar_wspd_hrrr_bias_correct(input_forcings, config_options, mpi_config, forc
 
         fhr = config_options.current_output_step
 
-        bias_corr = net_bias_SR + fhr * fhr_mult_SR + \
+        wspd_bias_corr = net_bias_SR + fhr * fhr_mult_SR + \
                     diurnal_ampl_SR * math.sin(diurnal_offs_SR + hh / 24 * 2*math.pi) + \
                     monthly_ampl_SR * math.sin(monthly_offs_SR + MM / 12 * 2*math.pi)
 


### PR DESCRIPTION
Missed renaming variable bias_corr -> wspd_bias_corr when upgrading to Joe Grim's bias correction equations.  This has been fixed in this pull.