### PR TITLE
Don't construct lat/long arrays before scattering.

### DIFF
--- a/core/regrid.py
+++ b/core/regrid.py
@@ -2368,19 +2368,19 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     lon_tmp = None
     if mpi_config.rank == 0:
         # Process lat/lon values from the GFS grid.
-        if len(id_tmp.variables['latitude'].shape) == 3:
+        if id_tmp.variables['latitude'].ndim == 3:
             # We have 2D grids already in place.
             lat_tmp = id_tmp.variables['latitude'][0, :, :]
             lon_tmp = id_tmp.variables['longitude'][0, :, :]
-        elif len(id_tmp.variables['longitude'].shape) == 2:
+        elif id_tmp.variables['longitude'].ndim == 2:
             # We have 2D grids already in place.
             lat_tmp = id_tmp.variables['latitude'][:, :]
             lon_tmp = id_tmp.variables['longitude'][:, :]
-        elif len(id_tmp.variables['latitude'].shape) == 1:
+        elif id_tmp.variables['latitude'].ndim == 1:
             # We have 1D lat/lons we need to translate into
             # 2D grids.
-            lat_tmp = np.repeat(id_tmp.variables['latitude'][:][:, np.newaxis], input_forcings.nx_global, axis=1)
-            lon_tmp = np.tile(id_tmp.variables['longitude'][:], (input_forcings.ny_global, 1))
+            lat_tmp = id_tmp.variables['latitude'][:]
+            lon_tmp = id_tmp.variables['longitude'][:]
     err_handler.check_program_status(config_options, mpi_config)
 
     # Scatter global GFS latitude grid to processors..
@@ -2412,8 +2412,12 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
-    input_forcings.esmf_lats[:, :] = var_sub_lat_tmp
-    input_forcings.esmf_lons[:, :] = var_sub_lon_tmp
+    if var_sub_lat_tmp.ndim == 1 and var_sub_lon_tmp.ndim == 1:
+        input_forcings.esmf_lats[:] = np.atleast_2d(var_sub_lat_tmp).T
+        input_forcings.esmf_lons[:] = np.atleast_2d(var_sub_lon_tmp)
+    else:
+        input_forcings.esmf_lats[:, :] = var_sub_lat_tmp
+        input_forcings.esmf_lons[:, :] = var_sub_lon_tmp
     del var_sub_lat_tmp
     del var_sub_lon_tmp
     del lat_tmp
@@ -2596,19 +2600,19 @@ def calculate_supp_pcp_weights(supplemental_precip, id_tmp, tmp_file, config_opt
     lat_tmp = lon_tmp = None
     if mpi_config.rank == 0:
         # Process lat/lon values from the GFS grid.
-        if len(id_tmp.variables['latitude'].shape) == 3:
+        if id_tmp.variables['latitude'].ndim == 3:
             # We have 2D grids already in place.
             lat_tmp = id_tmp.variables['latitude'][0, :, :]
             lon_tmp = id_tmp.variables['longitude'][0, :, :]
-        elif len(id_tmp.variables['longitude'].shape) == 2:
+        elif id_tmp.variables['longitude'].ndim == 2:
             # We have 2D grids already in place.
             lat_tmp = id_tmp.variables['latitude'][:, :]
             lon_tmp = id_tmp.variables['longitude'][:, :]
-        elif len(id_tmp.variables['latitude'].shape) == 1:
+        elif id_tmp.variables['latitude'].ndim == 1:
             # We have 1D lat/lons we need to translate into
             # 2D grids.
-            lat_tmp = np.repeat(id_tmp.variables['latitude'][:][:, np.newaxis], supplemental_precip.nx_global, axis=1)
-            lon_tmp = np.tile(id_tmp.variables['longitude'][:], (supplemental_precip.ny_global, 1))
+            lat_tmp = id_tmp.variables['latitude'][:]
+            lon_tmp = id_tmp.variables['longitude'][:]
     # mpi_config.comm.barrier()
 
     # Scatter global GFS latitude grid to processors..
@@ -2642,8 +2646,12 @@ def calculate_supp_pcp_weights(supplemental_precip, id_tmp, tmp_file, config_opt
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
-    supplemental_precip.esmf_lats[:, :] = var_sub_lat_tmp
-    supplemental_precip.esmf_lons[:, :] = var_sub_lon_tmp
+    if var_sub_lat_tmp.ndim == 1 and var_sub_lon_tmp.ndim == 1:
+        supplemental_precip.esmf_lats[:] = np.atleast_2d(var_sub_lat_tmp).T
+        supplemental_precip.esmf_lons[:] = np.atleast_2d(var_sub_lon_tmp)
+    else:
+        supplemental_precip.esmf_lats[:, :] = var_sub_lat_tmp
+        supplemental_precip.esmf_lons[:, :] = var_sub_lon_tmp
     del var_sub_lat_tmp
     del var_sub_lon_tmp
     del lat_tmp


### PR DESCRIPTION
This should reduce the overhead of scattering the arrays. Using broadcasting also reduces memory usage.