### PR TITLE
Improvements to layering module

### DIFF
--- a/core/layeringMod.py
+++ b/core/layeringMod.py
@@ -31,7 +31,7 @@ def layer_final_forcings(OutputObj,input_forcings,ConfigOptions,MpiConfig):
     for force_idx in input_forcings.input_map_output:
         outLayerCurrent = OutputObj.output_local[force_idx,:,:]
         layerIn = input_forcings.final_forcings[force_idx,:,:]
-        indSet = np.where(layerIn != ConfigOptions.globalNdv)
+        indSet = layerIn != ConfigOptions.globalNdv
         outLayerCurrent[indSet] = layerIn[indSet]
         OutputObj.output_local[force_idx, :, :] = outLayerCurrent
 

--- a/core/layeringMod.py
+++ b/core/layeringMod.py
@@ -48,20 +48,9 @@ def layer_supplemental_precipitation(OutputObj,supplemental_precip,ConfigOptions
     :param MpiConfig:
     :return:
     """
-    indSet = np.where(supplemental_precip.final_supp_precip != ConfigOptions.globalNdv)
     layerIn = supplemental_precip.final_supp_precip
-    layerOut = OutputObj.output_local[3,:,:]
-    if len(indSet[0]) != 0:
-        layerOut[indSet] = layerIn[indSet]
-    else:
-        # We have all missing data for the supplemental precip for this step.
-        layerOut = layerOut
-
-    OutputObj.output_local[3,:,:] = layerOut
-
-    # Reset local variables to reduce memory usage.
-    layerIn = None
-    layerOut = None
-    indSet = None
+    layerOut = OutputObj.output_local[3, :, :]
+    indSet = layerIn != ConfigOptions.globalNdv
+    layerOut[indSet] = layerIn[indSet]
 
     #MpiConfig.comm.barrier()

--- a/core/layeringMod.py
+++ b/core/layeringMod.py
@@ -33,10 +33,7 @@ def layer_final_forcings(OutputObj,input_forcings,ConfigOptions,MpiConfig):
         layerIn = input_forcings.final_forcings[force_idx,:,:]
         indSet = layerIn != ConfigOptions.globalNdv
         outLayerCurrent[indSet] = layerIn[indSet]
-        OutputObj.output_local[force_idx, :, :] = outLayerCurrent
 
-        # Reset for next iteration and memory efficiency.
-        indSet = None
     # MpiConfig.comm.barrier()
 
 

--- a/core/layeringMod.py
+++ b/core/layeringMod.py
@@ -28,16 +28,15 @@ def layer_final_forcings(OutputObj,input_forcings,ConfigOptions,MpiConfig):
     # 6.) Surface pressure (Pa)
     # 7.) Surface incoming shortwave radiation flux (W/m^2)
 
-    for force_idx in range(0,8):
-        if force_idx in input_forcings.input_map_output:
-            outLayerCurrent = OutputObj.output_local[force_idx,:,:]
-            layerIn = input_forcings.final_forcings[force_idx,:,:]
-            indSet = np.where(layerIn != ConfigOptions.globalNdv)
-            outLayerCurrent[indSet] = layerIn[indSet]
-            OutputObj.output_local[force_idx, :, :] = outLayerCurrent
+    for force_idx in input_forcings.input_map_output:
+        outLayerCurrent = OutputObj.output_local[force_idx,:,:]
+        layerIn = input_forcings.final_forcings[force_idx,:,:]
+        indSet = np.where(layerIn != ConfigOptions.globalNdv)
+        outLayerCurrent[indSet] = layerIn[indSet]
+        OutputObj.output_local[force_idx, :, :] = outLayerCurrent
 
-            # Reset for next iteration and memory efficiency.
-            indSet = None
+        # Reset for next iteration and memory efficiency.
+        indSet = None
     # MpiConfig.comm.barrier()
 
 


### PR DESCRIPTION
Small improvements to layering module:
1. When using numpy array views, we can modify the view to directly change the underlying array and, as a consequence, all references to it.
2. Only loop thru existing mapped outputs instead of checking if each possible output is mapped or not.
3. Use the boolean masks directly. We are already calculating them when we pass them to `np.where`.
