### PR TITLE
Adjust AnA bias correction hour to compensate for forecast shift

### DIFF
--- a/core/bias_correction.py
+++ b/core/bias_correction.py
@@ -441,6 +441,9 @@ def ncar_temp_hrrr_bias_correct(input_forcings, config_options, mpi_config, forc
 
     # determine if we're in AnA or SR configuration
     if config_options.ana_flag == 1:
+        hh -= config_options.output_freq / 60
+        if hh < 0:
+            hh += 24
         net_bias_AA = 0.019
         diurnal_ampl_AA = -0.06
         diurnal_offs_AA = 1.5
@@ -644,6 +647,9 @@ def ncar_wspd_hrrr_bias_correct(input_forcings, config_options, mpi_config, forc
 
     # determine if we're in AnA or SR configuration
     if config_options.ana_flag == 1:
+        hh -= config_options.output_freq / 60
+        if hh < 0:
+            hh += 24
         net_bias_AA = 0.23
         diurnal_ampl_AA = -0.13
         diurnal_offs_AA = -0.6


### PR DESCRIPTION
When applying HRRR bias corrections in AnA mode, the wrong hour is used in parameter calculation. This PR fixes that by subtracting one hour from the original value in AnA mode.