### PR TITLE
Set RqiMethod=0 by default

### DIFF
--- a/core/regrid.py
+++ b/core/regrid.py
@@ -2035,20 +2035,21 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
         supplemental_precip.esmf_field_out.data
     err_handler.check_program_status(config_options, mpi_config)
 
-    # Check for any RQI values below the threshold specified by the user.
-    # Set these values to global NDV.
-    try:
-        ind_filter = np.where(supplemental_precip.regridded_rqi2 < supplemental_precip.rqiThresh)
-        if len(ind_filter) > 0:
-            if mpi_config.rank == 0:
-                config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
-                err_handler.log_msg(config_options, mpi_config)
-        supplemental_precip.regridded_precip2[ind_filter] = config_options.globalNdv
-        del ind_filter
-    except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-        config_options.errMsg = "Unable to run MRMS RQI threshold search: " + str(npe)
-        err_handler.log_critical(config_options, mpi_config)
-    err_handler.check_program_status(config_options, mpi_config)
+    if supplemental_precip.rqiMethod > 0:
+        # Check for any RQI values below the threshold specified by the user.
+        # Set these values to global NDV.
+        try:
+            ind_filter = np.where(supplemental_precip.regridded_rqi2 < supplemental_precip.rqiThresh)
+            if len(ind_filter) > 0:
+                if mpi_config.rank == 0:
+                    config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
+                    err_handler.log_msg(config_options, mpi_config)
+            supplemental_precip.regridded_precip2[ind_filter] = config_options.globalNdv
+            del ind_filter
+        except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
+            config_options.errMsg = "Unable to run MRMS RQI threshold search: " + str(npe)
+            err_handler.log_critical(config_options, mpi_config)
+        err_handler.check_program_status(config_options, mpi_config)
 
     # Convert the hourly precipitation total to a rate of mm/s
     try:

--- a/core/suppPrecipMod.py
+++ b/core/suppPrecipMod.py
@@ -312,6 +312,9 @@ def initDict(ConfigOptions,GeoMetaWrfHydro):
         if ConfigOptions.rqiMethod is not None:
             InputDict[supp_pcp_key].rqiMethod = ConfigOptions.rqiMethod[supp_pcp_tmp]
             InputDict[supp_pcp_key].rqiThresh = ConfigOptions.rqiThresh[supp_pcp_tmp]
+        else:
+            InputDict[supp_pcp_key].rqiMethod = 0
+            InputDict[supp_pcp_key].rqiThresh = 1.0
 
     return InputDict
 


### PR DESCRIPTION
This fixes two issues:

- Code that tests for rqiMethod or rqiThreshold fail for suppPrecip that doesn't use RQI (like MRMS), because no default value was specified 
- MRMS regrid() was not testing for rqiMethod > 0 and comparing against rqiThreshold anyway (This really should be removed but I'm leaving it for now in case it's ever used in the future)