### PR TITLE
Add config option to enable LQFRAC output

### DIFF
--- a/Template/template_forcing_engine.config
+++ b/Template/template_forcing_engine.config
@@ -90,6 +90,11 @@ floatOutput = 0
 # 1 - Activate compression
 compressOutput = 0
 
+# Flag to include Liquid Water Fraction (LQFRAC), if inputs support internally
+# 0 - No LQFRAC output (default)
+# 1 - LQFRAC output 
+includeLQFraq = 0
+
 [Retrospective]
 # Specify to process forcings in retrosective mode
 # 0 - No

--- a/core/config.py
+++ b/core/config.py
@@ -97,6 +97,7 @@ class ConfigOptions:
         self.errFlag = 0
         self.nwmVersion = None
         self.nwmConfig = None
+        self.include_lqfraq = False
 
     def read_config(self):
         """
@@ -262,6 +263,20 @@ class ConfigOptions:
             err_handler.err_out_screen('Improper floatOutput value: {}'.format(config['Output']['floatOutput']))
         if self.useFloats < 0 or self.useFloats > 1:
             err_handler.err_out_screen('Please choose a floatOutput value of 0 or 1.')
+
+        # Read in lqfrac option
+        try:
+            self.include_lqfraq = int(config['Output'].get('includeLQFraq', 0))
+        except KeyError:
+            # err_handler.err_out_screen('Unable to locate includeLQFraq in the configuration file.')
+            self.include_lqfraq = 0
+        except configparser.NoOptionError:
+            # err_handler.err_out_screen('Unable to locate includeLQFraq in the configuration file.')
+            self.useFinclude_lqfraqloats = 0
+        except ValueError:
+            err_handler.err_out_screen('Improper includeLQFraq value: {}'.format(config['Output']['includeLQFraq']))
+        if self.include_lqfraq < 0 or self.include_lqfraq > 1:
+            err_handler.err_out_screen('Please choose a includeLQFraq value of 0 or 1.')
 
         # Read in retrospective options
         try:

--- a/core/ioMod.py
+++ b/core/ioMod.py
@@ -60,10 +60,13 @@ class OutputObj:
             'Q2D': [5,'kg kg-1','surface_specific_humidity','2-m Specific Humidity','time: point',0.000001,0.0,6],
             'PSFC': [6,'Pa','air_pressure','Surface Pressure','time: point',0.1,0.0,1],
             'SWDOWN': [7,'W m-2','surface_downward_shortwave_flux',
-                       'Surface downward short-wave radiation flux','time: point',0.001,0.0,3],
-            'LQFRAC': [8, '%', 'liquid_water_fraction', 'Fraction of precipitation that is liquid vs. frozen',
-                       'time: point', 0.1, 0.0, 3]
+                       'Surface downward short-wave radiation flux','time: point',0.001,0.0,3]
         }
+
+        if ConfigOptions.include_lqfraq:
+            output_variable_attribute_dict['LQFRAQ'] = [8, '%', 'liquid_water_fraction',
+                                                        'Fraction of precipitation that is liquid vs. frozen',
+                                                        'time: point', 0.1, 0.0, 3]
 
         # Compose the ESMF remapped string attribute based on the regridding option chosen by the user.
         # We will default to the regridding method chosen for the first input forcing selected.


### PR DESCRIPTION
Add an option to the config file to enable/disable LQFRAC output. Output will be disabled by default.