### PR TITLE
Change `model_total_valid_times` attrib to int32

### DIFF
--- a/core/ioMod.py
+++ b/core/ioMod.py
@@ -162,7 +162,7 @@ class OutputObj:
                     break
 
                 try:
-                    idOut.model_total_valid_times = float(ConfigOptions.actual_output_steps)
+                    idOut.model_total_valid_times = np.int32(ConfigOptions.actual_output_steps)
                 except:
                     ConfigOptions.errMsg = "Unable to create total_valid_times global attribute in: " + self.outPath
                     err_handler.log_critical(ConfigOptions, MpiConfig)


### PR DESCRIPTION
Change the `model_total_valid_times` from a 64-bit float to a 32-bit integer, for consistency with other NWM output files.