### PR TITLE
Update missing value and and ignore global metadata

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -93,7 +93,7 @@ class ConfigOptions:
         self.customFcstFreq = None
         self.rqiMethod = None
         self.rqiThresh = 1.0
-        self.globalNdv = -9999.0
+        self.globalNdv = -999999.0
         self.d_program_init = datetime.datetime.utcnow()
         self.errFlag = 0
         self.nwmVersion = None
@@ -1115,7 +1115,7 @@ class ConfigOptions:
             except configparser.NoOptionError:
                 err_handler.err_out_screen('Unable to locate SuppPcpDirectories in SuppForcing section '
                                            'in the configuration file.')
-        
+
             # Loop through and ensure all supp pcp directories exist. Also strip out any whitespace
             # or new line characters.
             for dirTmp in range(0, len(self.supp_precip_dirs)):
@@ -1123,7 +1123,7 @@ class ConfigOptions:
                 if not os.path.isdir(self.supp_precip_dirs[dirTmp]):
                     err_handler.err_out_screen('Unable to locate supp pcp directory: ' + self.supp_precip_dirs[dirTmp])
 
-            #Special case for ExtAnA where we treat comma separated stage IV, MRMS data as one SuppPcp input 
+            #Special case for ExtAnA where we treat comma separated stage IV, MRMS data as one SuppPcp input
             if 11 in self.supp_precip_forcings:
                 if len(self.supp_precip_forcings) != 1:
                     err_handler.err_out_screen('Alaska Stage IV/MRMS SuppPcp option is only supported as a standalone option')
@@ -1295,4 +1295,4 @@ class ConfigOptions:
             hrs_since_start = self.current_output_date - self.current_fcst_cycle
             return hrs_since_start <= datetime.timedelta(hours = self.supp_pcp_max_hours)
         else:
-            return True 
+            return True

--- a/core/forecastMod.py
+++ b/core/forecastMod.py
@@ -123,7 +123,7 @@ def process_forecasts(ConfigOptions, wrfHydroGeoMeta, inputForcingMod, suppPcpMo
         show_message = True
         for outStep in range(1, ConfigOptions.num_output_steps + 1):
             # Reset out final grids to missing values.
-            OutputObj.output_local[:, :, :] = -9999.0
+            OutputObj.output_local[:, :, :] = ConfigOptions.globalNdv
 
             ConfigOptions.current_output_step = outStep
             OutputObj.outDate = ConfigOptions.current_fcst_cycle + datetime.timedelta(
@@ -229,7 +229,7 @@ def process_forecasts(ConfigOptions, wrfHydroGeoMeta, inputForcingMod, suppPcpMo
 
                     if forceKey == 10:
                         ConfigOptions.currentCustomForceNum = ConfigOptions.currentCustomForceNum + 1
-                
+
                 else:
                     # Process supplemental precipitation if we specified in the configuration file.
                     if ConfigOptions.number_supp_pcp > 0:

--- a/core/ioMod.py
+++ b/core/ioMod.py
@@ -26,7 +26,7 @@ class OutputObj:
         self.output_local = None
         self.outPath = None
         self.outDate = None
-        self.out_ndv = -9999
+        self.out_ndv = -999999
 
         # Create local "slabs" to hold final output grids. These
         # will be collected during the output routine below.

--- a/core/ioMod.py
+++ b/core/ioMod.py
@@ -171,7 +171,7 @@ class OutputObj:
                 if ConfigOptions.spatial_meta is not None:
                     # apply spatial_global_atts to output globals attrs
                     for k, v in geoMetaWrfHydro.spatial_global_atts.items():
-                        if k not in ("Source_Software", "history", "processing_notes"):     # don't add these
+                        if k not in ("Source_Software", "history", "processing_notes", "version"):     # don't add these
                             idOut.setncattr(k, v)
 
                 # Create variables.


### PR DESCRIPTION
* Change globalNdv / netCDF missing_value from -9999 to -999999, to avoid scaled winds getting marked as invalid
* Add `version` to ignored global metadata attributes to avoid confusion, since the FE already adds a similar attribute