### PR TITLE
Update numpy and esmpy

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -681,7 +681,7 @@ class ConfigOptions:
 
         # Read in the temperature downscaling options.
         # Create temporary array to hold flags of if we need input parameter files.
-        param_flag = np.empty([len(self.input_forcings)], np.int)
+        param_flag = np.empty([len(self.input_forcings)], int)
         param_flag[:] = 0
         try:
             self.t2dDownscaleOpt = json.loads(config['Downscaling']['TemperatureDownscaling'])

--- a/core/disaggregateMod.py
+++ b/core/disaggregateMod.py
@@ -113,9 +113,9 @@ def ext_ana_disaggregate(input_forcings, supplemental_precip, config_options, mp
 
     ana_sum = np.array([],dtype=np.float32)
     target_data = np.array([],dtype=np.float32)
-    ana_all_zeros = np.array([],dtype=np.bool)
-    ana_no_zeros = np.array([],dtype=np.bool)
-    target_data_no_zeros = np.array([],dtype=np.bool)
+    ana_all_zeros = np.array([],dtype=bool)
+    ana_no_zeros = np.array([],dtype=bool)
+    target_data_no_zeros = np.array([],dtype=bool)
     if mpi_config.rank == 0:
         config_options.statusMsg = f"Performing hourly disaggregation of {supplemental_precip.file_in2}"
         err_handler.log_msg(config_options, mpi_config)

--- a/core/downscale.py
+++ b/core/downscale.py
@@ -737,9 +737,9 @@ def TOPO_RAD_ADJ_DRVR(GeoMetaWrfHydro,input_forcings,COSZEN,declin,solcon,hrang2
 
     COSZEN[np.where(COSZEN < 1E-4)] = 1E-4
 
-    corr_frac = np.empty([ny, nx], np.int)
-    # shadow_mask = np.empty([ny,nx],np.int)
-    diffuse_frac = np.empty([ny, nx], np.int)
+    corr_frac = np.empty([ny, nx], int)
+    # shadow_mask = np.empty([ny,nx],int)
+    diffuse_frac = np.empty([ny, nx], int)
     corr_frac[:, :] = 0
     diffuse_frac[:, :] = 0
     # shadow_mask[:,:] = 0

--- a/core/geoMod.py
+++ b/core/geoMod.py
@@ -1,6 +1,6 @@
 import math
 
-import ESMF
+import esmpy as ESMF
 import numpy as np
 from netCDF4 import Dataset
 

--- a/core/parallel.py
+++ b/core/parallel.py
@@ -140,7 +140,7 @@ class MpiConfig:
                 data_type_flag = 1
             if src_array.dtype == np.float64:
                 data_type_flag = 2
-            if src_array.dtype == np.bool:
+            if src_array.dtype == bool:
                 data_type_flag = 3
 
         # Broadcast the data_type_flag to other processors
@@ -206,7 +206,7 @@ class MpiConfig:
             recvbuf=np.empty([counts[self.rank]],np.float32)
         elif data_type_flag == 3: 
             data_type = MPI.BOOL
-            recvbuf = np.empty([counts[self.rank]], np.bool)
+            recvbuf = np.empty([counts[self.rank]], bool)
         else:
             data_type = MPI.DOUBLE
             recvbuf = np.empty([counts[self.rank]], np.float64)

--- a/core/regrid.py
+++ b/core/regrid.py
@@ -7,7 +7,7 @@ import sys
 import traceback
 import time
 
-import ESMF
+import esmpy as ESMF
 import numpy as np
 
 from core import err_handler

--- a/genForcing.py
+++ b/genForcing.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 
-import ESMF
+import esmpy as ESMF
 
 from core import config
 from core import err_handler


### PR DESCRIPTION
Hi

I'm using a recent install of conda and python on Ubuntu 22.04,  and had to make the following changes to your library:

- for numpy >= 1.20 -> https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
- for esmpy > 8.4.0 ->  https://earthsystemmodeling.org/esmpy_doc/release/latest/html/install.html

"Note The Python module name for ESMPy was changed in v8.4.0 from “ESMF” to “esmpy”. If you are using a version older than v8.4.0, the import command is import ESMF. See the [ESMF Release Notes](http://earthsystemmodeling.org/static/releases.html) for more details and links to previous versions of the ESMPy documentation."

My package versions are:

- python 3.11.4
- numpy 1.24.4
- esmpy 8.4.2 
- conda 23.5.2 
- Ubuntu 22.04

