### PR TITLE
Feature/nbm lqfrac support

### DIFF
--- a/Template/template_forcing_engine_NBM_LQFrac.config
+++ b/Template/template_forcing_engine_NBM_LQFrac.config
@@ -1,0 +1,355 @@
+#--------------------------------------------------------------------
+# WRF-Hydro Forcing Engine Configuration File
+#
+# Input options to the forcing engine include:
+# 1.) Choices for input forcing files to use.
+# 2.) Options for specifying date ranges and forecast intervals
+#     for input files.
+# 3.) Choices for ESMF regridding techniques.
+# 4.) Choices for optional downscaling techniques.
+# 5.) Choices for optional bias correction techniques.
+# 6.) Choices for optional supplemental precipitation products.
+# 7.) Choices for optional ensemble member variations.
+# 8.) Choices for output directories to place final output files.
+
+[Input]
+# Choose a set of value(s) of forcing variables to be processed for
+# WRF-Hydro. Please be advised that the order of which the values are
+# chosen below are the order that the final products will be layered
+# into the final LDASIN files. See documentation for additional
+# information and examples.
+# The following is a global set of key values to map forcing files
+# to variables within LDASIN files for WRF-Hydro. The forcing engine
+# will map files to external variable names internally. For custom
+# external native forcing files (see documenation), the code will
+# expect a set of named variables to process. The following is a
+# mapping of numeric values to external input native forcing files:
+# 1 - NLDAS GRIB retrospective files
+# 2 - NARR GRIB retrospective files
+# 3 - GFS GRIB2 Global production files on the full gaussian grid
+# 4 - NAM Nest GRIB2 Conus production files
+# 5 - HRRR GRIB2 Conus production files
+# 6 - RAP GRIB2 Conus 13km production files
+# 7 - CFSv2 6-hourly GRIB2 Global production files
+# 8 - WRF-ARW - GRIB2 Hawaii nest files
+# 9 - GFS GRIB2 Global production files on 0.25 degree lat/lon grids. 
+# 10 - Custom NetCDF hourly forcing files
+# 11 - Custom NetCDF hourly forcing files
+# 12 - Custom NetCDF hourly forcing files
+# 13 - Hawaii 3-km NAM Nest.
+# 14 - Puerto Rico 3-km NAM Nest.
+# 15 - Alaska 3-km Alaska NAM Nest
+# 16 - NAM_Nest_3km_Hawaii_Radiation-Only
+# 17 - NAM_Nest_3km_PuertoRico_Radiation-Only
+# 18 - WRF-ARW GRIB2 PuertoRico
+# 19 - HRRR GRIB2 Alaska production files
+InputForcings = [21]
+
+# Specify the file type for each forcing (co02a separated)
+# Valid types are GRIB1, GRIB2, and NETCDF
+# (GRIB files will be converted internally with WGRIB[2])
+InputForcingTypes = GRIB2
+
+# Specify the input directories for each forcing product.
+InputForcingDirectories = /DATA/NBM/noaa-nbm-grib2-pds_JTTI
+
+# Specify whether the input forcings listed above are mandatory, or optional.
+# This is important for layering contingencies if a product is missing,
+# but forcing files are still desired.
+# 0 - Not mandatory
+# 1 - Mandatory
+# NOTE!!! If not files are found for any products, code will error out indicating
+# the final field is all missing values.
+InputMandatory = [1]
+
+[Output]
+# Specify the output frequency in minutes. 
+# Note that any frequencies at higher intervals
+# than what is provided as input will entail input
+# forcing data being temporally interpolated.
+OutputFrequency = 60
+
+# Specify a top level output directory. For re-forecasts
+# and forecasts, sub-directories for each forecast cycle
+# will be generated. For retrospective processing, final
+# output files will be placed in this directory. 
+OutDir = /FE_NBM_test
+
+# Specify a scratch directory that will be used 
+# for storage of temporary files. These files
+# will be r03ved automatically by the program. 
+ScratchDir = /FE_NBM_test/tmp
+
+# Flag to use floating point output vs scale_factor / add_offset byte packing in
+# the output files (the default)
+# 0 - Use scale/offset encoding
+# 1 - Use floating-point encoding
+floatOutput = 0
+
+# Flag to activate netCDF4 deflate compression in the output files.
+# 0 - Deactivate compression
+# 1 - Activate compression
+compressOutput = 0
+
+# Flag to include Liquid Water Fraction (LQFRAC), if inputs support internally
+# 0 - No LQFRAC output (default)
+# 1 - LQFRAC output 
+includeLQFraq = 1
+
+[Retrospective]
+# Specify to process forcings in retrosective mode
+# 0 - No
+# 1 - Yes
+RetroFlag = 0
+
+# Choose the beginning date of processing forcing files.
+# NOTE - Dates are given in YYYYMMDDHHMM format
+# If in real-time forecasting mode, leave as -9999.
+# These dates get over-ridden in lookBackHours.
+BDateProc = 202109010000
+EDateProc = 202109020000
+
+[Forecast]
+# Specify if this is an Analysis and Assimilation run (AnA).
+# If this is AnA run, set AnAFlag to 1, otherwise 0.
+# Setting this flag will change the behavior of some Bias Correction routines as wel
+# as the ForecastInputOffsets options (see below for more information)
+AnAFlag = 0
+
+# ONLY for realtime forecasting.
+# - Specify a lookback period in minutes to process data.
+#   This overrides any BDateProc/EDateProc options passed above.
+#   If no LookBack specified, please specify -9999.
+LookBack = -9999
+
+# If running reforecasts, specify a window below. This will override 
+# using the LookBack value to calculate a processing window. 
+RefcstBDateProc = 202205010000
+RefcstEDateProc = 202205020000
+
+# Specify a forecast frequency in minutes. This value specifies how often
+# to generate a set of forecast forcings. If generating hourly retrospective
+# forcings, specify this value to be 60. 
+ForecastFrequency = 1440
+
+# Forecast cycles are determined by splitting up a day by equal 
+# ForecastFrequency interval. If there is a desire to shift the
+# cycles to a different time step, ForecastShift will shift forecast
+# cycles ahead by a determined set of minutes. For example, ForecastFrequency
+# of 6 hours will produce forecasts cycles at 00, 06, 12, and 18 UTC. However,
+# a ForecastShift of 1 hour will produce forecast cycles at 01, 07,
+# 13, and 18 UTC. NOTE - This is only used by the realtime instance 
+# to calculate forecast cycles accordingly. Re-forecasts will use the beginning
+# and ending dates specified in conjunction with the forecast frequency
+# to determine forecast cycle dates.  
+ForecastShift = 0
+
+# Specify how much (in minutes) of each input forcing is desires for each 
+# forecast cycle. See documentation for examples. The length of
+# this array must match the input forcing choices.
+ForecastInputHorizons = [14400] 
+
+# This option is for applying an offset to input forcings to use a different
+# forecasted interval. For example, a user may wish to use 4-5 hour forecasted
+# fields from an NWP grid from one of their input forcings. In that instance
+# the offset would be 4 hours, but 0 for other remaining forcings. 
+#
+# In AnA runs, this value is the offset from the available forecast and 00z
+# For example, if forecast are available at 06z and 18z, set this value to 6
+ForecastInputOffsets = [0]
+
+[Geospatial]
+# Specify a geogrid file that defines the WRF-Hydro (or NWM) domain to which
+# the forcings are being processed to.
+GeogridIn = /glade/p/cisl/nwc/nwmv21_finals/CONUS/DOMAIN_FinalParams/geo_em.d01.conus_1km_NWMv2.1_XLATC_XLONC.nc
+
+# Specify the optional land spatial metadata file. If found, coordinate projection information
+# and coordinate will be translated from to the final output file.
+SpatialMetaIn = /glade/p/cisl/nwc/nwmv21_finals/CONUS/DOMAIN_FinalParams/GEOGRID_LDASOUT_Spatial_Metadata_1km_NWMv2.1.nc
+
+# Specifiy the optional grid metadata file. For NBM, this includes a height field.
+GridMeta = Test/NBM/nbm_conus_terrain_v2p5.gb2
+
+# Specify a border width (in grid cells) to ignore for each input dataset.
+# NOTE: generally, the first input forcing should always be zero or there will be missing data in the final output
+IgnoredBorderWidths = [0]
+
+[Regridding]
+# Choose regridding options for each input forcing files being used. Options available are:
+# 1 - ESMF Bilinear
+# 2 - ESMF Nearest Neighbor
+# 3 - ESMF Conservative Bilinear
+RegridOpt = [1]
+# RegridWeightsDir = /glade/p/cisl/nwc/nwm_forcings/ESMFWeightFiles
+
+[Interpolation]
+# Specify an temporal interpolation for the forcing variables.
+# Interpolation will be done between the two neighboring
+# input forcing states that exist. If only one nearest
+# state exist (I.E. only a state forward in time, or behind),
+# then that state will be used as a "nearest neighbor".
+# NOTE - All input options here must be of the same length
+# of the input forcing number. Also note all temporal interpolation
+# occurs BEFORE downscaling and bias correction.
+# 0 - No temporal interpolation.
+# 1 - Nearest Neighbor
+# 2 - Linear weighted average
+ForcingTemporalInterpolation = [0]
+
+[BiasCorrection]
+# Choose bias correction options for each of the input forcing files. Length of each option
+# must match the length of input forcings.
+
+# Specify a temperature bias correction method.
+# 0 - No bias correction
+# 1 - CFSv2 - NLDAS2 Parametric Distribution - NWM ONLY
+# 2 - Custom NCAR bias-correction based on HRRRv3 analysis - based on hour of day (USE WITH CAUTION).
+# 3 - NCAR parametric GFS bias correction
+# 4 - NCAR parametric HRRR bias correction
+TemperatureBiasCorrection = [0]
+
+# Specify a surface pressure bias correction method.
+# 0 - No bias correction.
+# 1 - CFSv2 - NLDAS2 Parametric Distribution - NWM ONLY
+PressureBiasCorrection = [0]
+
+# Specify a specific humidity bias correction method.
+# 0 - No bias correction.
+# 1 - CFSv2 - NLDAS2 Parametric Distribution - NWM ONLY
+# 2 - Custom NCAR bias-correction based on HRRRv3 analysis - based on hour of day (USE WITH CAUTION).
+HumidityBiasCorrection = [0]
+
+# Specify a wind bias correction.
+# 0 - No bias correction.
+# 1 - CFSv2 - NLDAS2 Parametric Distribution - NWM ONLY
+# 2 - Custom NCAR bias-correction based on HRRRv3 analysis - based on hour of day (USE WITH CAUTION).
+# 3 - NCAR parametric GFS bias correction
+# 4 - NCAR parametric HRRR bias correction
+WindBiasCorrection = [0]
+
+# Specify a bias correction for incoming short wave radiation flux.
+# 0 - No bias correction.
+# 1 - CFSv2 - NLDAS2 Parametric Distribution - NWM ONLY
+# 2 - Custom NCAR bias-correction based on HRRRv3 analysis (USE WITH CAUTION).
+SwBiasCorrection = [0]
+
+# Specify a bias correction for incoming long wave radiation flux.
+# 0 - No bias correction.
+# 1 - CFSv2 - NLDAS2 Parametric Distribution - NWM ONLY
+# 2 - Custom NCAR bias-correction based on HRRRv3 analysis, blanket adjustment (USE WITH CAUTION).
+# 3 - NCAR parametric GFS bias correction
+LwBiasCorrection = [0]
+
+# Specify a bias correction for precipitation.
+# 0 - No bias correction.
+# 1 - CFSv2 - NLDAS2 Parametric Distribution - NWM ONLY
+PrecipBiasCorrection = [0]
+
+[Downscaling]
+# Choose downscaling options for each of the input forcing files. Length of each option
+# must match the length of input forcings.
+
+# Specify a temperature downscaling method:
+# 0 - No downscaling.
+# 1 - Use a simple lapse rate of 6.75 degrees Celsius to get from the model elevation
+#     to the WRF-Hydro elevation.
+# 2 - Use a pre-calculated lapse rate regridded to the WRF-Hydro domain.
+TemperatureDownscaling = [1]
+
+# Specify a surface pressure downscaling method:
+# 0 - No downscaling.
+# 1 - Use input elevation and WRF-Hydro elevation to downscale
+#     surface pressure.
+PressureDownscaling = [0]
+
+# Specify a shortwave radiation downscaling routine.
+# 0 - No downscaling
+# 1 - Run a topographic adjustment using the WRF-Hydro elevation
+ShortwaveDownscaling = [0]
+
+# Specify a precipitation downscaling routine.
+# 0 - No downscaling
+# 1 - NWM mountain mapper downscaling using monthly PRISM climo.
+PrecipDownscaling = [0]
+
+# Specify a specific humidity downscaling routine.
+# 0 - No downscaling
+# 1 - Use regridded humidity, along with downscaled temperature/pressure
+#     to extrapolate a downscaled surface specific humidty.
+HumidityDownscaling = [0]
+
+# Specify the input parameter directory containing necessary downscaling grids.
+# DownscalingParamDirs = /glade/p/cisl/nwc/nwm_forcings/NWM_v21_Params/Alaska
+DownscalingParamDirs = /glade/p/cisl/nwc/zhangyx/NWM_v21_Params/Alaska
+
+[SuppForcing]
+# Choose a set of supplemental precipitation file(s) to layer
+# into the final LDASIN forcing files processed from
+# the options above. The following is a mapping of
+# numeric values to external input native forcing files:
+# 1 - MRMS GRIB2 hourly radar-only QPE
+# 2 - MRMS GRIB2 hourly gage-corrected radar QPE
+# 3 - WRF-ARW 2.5 km 48-hr Hawaii nest precipitation.
+# 4 - WRF-ARW 2.5 km 48-hr Puerto Rico nest precipitation.
+# 5 - CONUS MRMS MultiSensor Pass1 and Pass1
+# 6 - Hawaii MRMS MultiSensor Pass1 and Pass2
+# 7 - Alaska MRMS MultiSensor Pass1 and Pass2
+# 8 - NBM Conus MR
+# 9 - NBM Alaska MR
+SuppPcp = []
+
+# Specify the file type for each supplemental precipitation file (co02a separated)
+# Valid types are GRIB1, GRIB2, and NETCDF
+# (GRIB files will be converted internally with WGRIB[2])
+SuppPcpForcingTypes = []
+
+# Specify the correponding supplemental precipitation directories
+# that will be searched for input files.
+SuppPcpDirectories = 
+
+# Specify whether the Supplemental Precips listed above are mandatory, or optional.
+# This is important for layering contingencies if a product is missing,
+# but forcing files are still desired.
+# 0 - Not mandatory
+# 1 - Mandatory
+SuppPcpMandatory = []
+
+# Specify regridding options for the supplemental precipitation products.
+RegridOptSuppPcp = []
+
+# Specify the time interpretation methods for the supplemental precipitation
+# products.
+SuppPcpTemporalInterpolation = []
+
+# In AnA runs, this value is the offset from the available forecast and 00z
+# For example, if forecast are available at 06z and 18z, set this value to 6 
+SuppPcpInputOffsets = []
+
+# Optional RQI method for radar-based data.
+# 0 - Do not use any RQI filtering. Use all radar-based estimates.
+# 1 - Use hourly MRMS Radar Quality Index grids.
+# 2 - Use NWM monthly climatology grids (NWM only!!!!)
+RqiMethod = 0
+
+# Optional RQI threshold to be used to mask out. Currently used for MRMS products.
+# Please choose a value from 0.0-1.0. Associated radar quality index files will be expected
+# from MRMS data.
+RqiThreshold = 0.9 
+
+# Specify an optional directory that contains supplemental precipitation parameter fields,
+# I.E monthly RQI climatology
+#SuppPcpParamDir = /glade/p/cisl/nwc/nwm_forcings/NWM_v21_Params/Short_Range
+
+[Ensembles]
+# Choose ensemble options for each input forcing file being used. Ensemble options include:
+# FILL IN ENSEMBLE OPTIONS HERE.....
+# Choose the CFS ensemble member number to process
+cfsEnsNumber = 
+
+[Custom]
+# These are options for specifying custom input NetCDF forcing files (in minutes).
+# Choose the input frequency of files that are being processed. I.E., are the
+# input files every 15 minutes, 60 minutes, 3-hours, etc. Please specify the
+# length of custom input frequencies to match the number of custom NetCDF inputs
+# selected above in the Logistics section.
+custom_input_fcst_freq = []

--- a/core/forcingInputMod.py
+++ b/core/forcingInputMod.py
@@ -344,7 +344,7 @@ class input_forcings:
                 'PRES_surface'],
             20: ['U2D', 'V2D', 'LWDOWN', 'RAINRATE', 'T2D',
                  'Q2D', 'PSFC', 'SWDOWN'],
-            21: ['TMP_2maboveground', 'APCP_surface', 'PTYPE_surface']
+            21: ['TMP_2maboveground', 'APCP_surface', 'PTYPE_liquid']
         }
         self.netcdf_var_names = netcdf_variables[self.keyValue]
 

--- a/core/forcingInputMod.py
+++ b/core/forcingInputMod.py
@@ -558,6 +558,10 @@ def initDict(ConfigOptions,GeoMetaWrfHydro):
         InputDict[force_key].final_forcings = np.empty([8,GeoMetaWrfHydro.ny_local,
                                                         GeoMetaWrfHydro.nx_local],
                                                        np.float64)
+        if ConfigOptions.include_lqfraq and InputDict[force_key].productName == 'NBM' :
+            InputDict[force_key].final_forcings = np.empty([9,GeoMetaWrfHydro.ny_local,
+                                                            GeoMetaWrfHydro.nx_local],
+                                                        np.float64)
         InputDict[force_key].height = np.empty([GeoMetaWrfHydro.ny_local,
                                                 GeoMetaWrfHydro.nx_local],np.float32)
         InputDict[force_key].regridded_mask = np.empty([GeoMetaWrfHydro.ny_local,

--- a/core/forcingInputMod.py
+++ b/core/forcingInputMod.py
@@ -230,7 +230,7 @@ class input_forcings:
                  'DLWRF', 'PRES'],
             20: ['U2D', 'V2D', 'LWDOWN', 'RAINRATE', 'T2D',
                  'Q2D', 'PSFC', 'SWDOWN'],
-            21: ['TMP', 'APCP']
+            21: ['TMP', 'APCP', 'PTYPE']
         }
         self.grib_vars = grib_vars_in[self.keyValue]
 
@@ -279,7 +279,7 @@ class input_forcings:
                 '10 m above ground', '10 m above ground',
                 'surface', 'surface', 'surface', 'surface'],
             20: None,
-            21: ['2 m above ground', 'surface']
+            21: ['2 m above ground', 'surface', 'surface']
         }
         self.grib_levels = grib_levels_in[self.keyValue]
 
@@ -344,7 +344,7 @@ class input_forcings:
                 'PRES_surface'],
             20: ['U2D', 'V2D', 'LWDOWN', 'RAINRATE', 'T2D',
                  'Q2D', 'PSFC', 'SWDOWN'],
-            21: ['TMP_2maboveground', 'APCP_surface']
+            21: ['TMP_2maboveground', 'APCP_surface', 'PTYPE_surface']
         }
         self.netcdf_var_names = netcdf_variables[self.keyValue]
 
@@ -396,7 +396,7 @@ class input_forcings:
             18: [4, 5, 0, 1, 3, 6],
             19: [4,5,0,1,3,7,2,6],
             20: [0,1,2,3,4,5,6,7],
-            21: [4, 3]
+            21: [4, 3, 8] # 8 is the LQFRAC liquid water fraction
         }
         self.input_map_output = input_map_to_outputs[self.keyValue]
 

--- a/core/ioMod.py
+++ b/core/ioMod.py
@@ -524,6 +524,13 @@ def open_grib2(GribFileIn,NetCdfFileOut,Wgrib2Cmd,ConfigOptions,MpiConfig,
             #                             stderr=subprocess.PIPE, shell=True)
             #out, err = cmdOutput.communicate()
             #exitcode = cmdOutput.returncode
+            
+            if (ConfigOptions.include_lqfraq and os.path.basename(NetCdfFileOut)[:3] == 'NBM'):
+                ConfigOptions.statusMsg = "Adding up NBM PTYPE layers liquid-rain (1<p<2) + freezing-rain (3<p<4)"
+                err_handler.log_msg(ConfigOptions, MpiConfig)
+                ncap2Cmd = f"ncap2 -O -s 'PTYPE_liquid=(PTYPE_prob_GE_1_LT_2_prob_fcst_1_1_surface+PTYPE_prob_GE_3_LT_4_prob_fcst_1_1_surface)*0.01 << 1' {NetCdfFileOut} {NetCdfFileOut}"
+                exitcode = subprocess.call(ncap2Cmd, shell=True)
+            
         except:
             ConfigOptions.errMsg = "Unable to convert: " + GribFileIn + " to " + \
                                    NetCdfFileOut

--- a/core/layeringMod.py
+++ b/core/layeringMod.py
@@ -28,8 +28,10 @@ def layer_final_forcings(OutputObj,input_forcings,ConfigOptions,MpiConfig):
     # 5.) 2-meter specific humidity (kg/kg)
     # 6.) Surface pressure (Pa)
     # 7.) Surface incoming shortwave radiation flux (W/m^2)
+    # 8.) Liquid Water Fraction (unitless), if included in the .config file
 
-    for force_idx in range(0,8):
+
+    for force_idx in range(0, 9 if ConfigOptions.include_lqfraq else 8):
         if force_idx in input_forcings.input_map_output:
             outLayerCurrent = OutputObj.output_local[force_idx,:,:]
             layerIn = input_forcings.final_forcings[force_idx,:,:]

--- a/core/regrid.py
+++ b/core/regrid.py
@@ -2646,8 +2646,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
                           + time_str + ":")
         # fields.append(":(HGT):(surface):")
         # Create a temporary NetCDF file from the GRIB2 file.
-        cmd = '$WGRIB2 -match "(' + '|'.join(fields) + ')" -not "prob" -not "ens" ' + \
-              forcings_or_precip.file_in1 + " -netcdf " + nbm_tmp_nc
+        cmd = '$WGRIB2 ' + forcings_or_precip.file_in1 + " -set_ext_name 1 -netcdf " + nbm_tmp_nc
     else:
         # Perform a GRIB dump to NetCDF for the precip data.
         fieldnbm_match1 = "\":APCP:\""

--- a/core/regrid.py
+++ b/core/regrid.py
@@ -2880,6 +2880,11 @@ def check_regrid_status(id_tmp, force_count, input_forcings, config_options, wrf
                                                       np.float32)
         input_forcings.regridded_forcings2 = np.empty([8, wrf_hydro_geo_meta.ny_local, wrf_hydro_geo_meta.nx_local],
                                                       np.float32)
+        if config_options.include_lqfraq and input_forcings.productName == 'NBM' :
+            input_forcings.regridded_forcings1 = np.empty([9, wrf_hydro_geo_meta.ny_local, wrf_hydro_geo_meta.nx_local],
+                                                        np.float32)
+            input_forcings.regridded_forcings2 = np.empty([9, wrf_hydro_geo_meta.ny_local, wrf_hydro_geo_meta.nx_local],
+                                                        np.float32)            
 
     if mpi_config.rank == 0:
         if input_forcings.nx_global is None or input_forcings.ny_global is None:


### PR DESCRIPTION
This branch extends the output layers of the NBM forcing option, so that liquid-water-fraction will be read from the source NBM files layer:precipitation-type (PTYPE) and will be processed and written to the output files. User needs to turn on the option `includeLQFraq = 1` in the `.config` file when the 'NBM' option is speficied as the input sorce (i.e., `InputForcings = [21]`).

The code has successfully passed a test on Derecho machine. 