### PR TITLE
Reorder import statements, support newer esmpy vesions

### DIFF
--- a/core/downscale.py
+++ b/core/downscale.py
@@ -426,7 +426,7 @@ def nwm_monthly_PRISM_downscale(input_forcings,ConfigOptions,GeoMetaWrfHydro,Mpi
     if mmVersion == None:
         ConfigOptions.errMsg = "Invalid Mountain Mapper Precip Downscaling option\n"
         err_handler.log_critical(ConfigOptions, MpiConfig)
- 
+
     if input_forcings.nwmPRISM_denGrid is None and input_forcings.nwmPRISM_numGrid is None:
         # We are on situation 1 - This is the first output step.
         initialize_flag = True
@@ -580,11 +580,11 @@ def nwm_monthly_PRISM_downscale(input_forcings,ConfigOptions,GeoMetaWrfHydro,Mpi
     hourlyGrid = input_forcings.final_forcings[3,:,:]
     tmpGrid = np.full([GeoMetaWrfHydro.ny_local, GeoMetaWrfHydro.nx_local], -9999.0, dtype=float)
     ratioRainGrid = np.full([GeoMetaWrfHydro.ny_local, GeoMetaWrfHydro.nx_local], -9999.0, dtype=float)
- 
+
     localRainRate = input_forcings.final_forcings[3,:,:]
     numLocal = input_forcings.nwmPRISM_numGrid
     denLocal = input_forcings.nwmPRISM_denGrid
- 
+
     # Establish index of where we have valid data.
     try:
         indValid = np.where((localRainRate != -9999.0) & (denLocal != -9999.0) & (denLocal > 1.0))
@@ -630,26 +630,26 @@ def nwm_monthly_PRISM_downscale(input_forcings,ConfigOptions,GeoMetaWrfHydro,Mpi
     count = len(indValid[0])
     if count > 0:
         ratioRainGrid[indValid] = hourlyGrid[indValid]/3600
-   
+
     try:
        indValid = np.where(ratioRainGrid != -9999.0)
 
-    except:   
+    except:
        ConfigOptions.errMsg = "Unable to run numpy search for valid values on precip and " \
                               "param grid in mountain mapper downscaling"
        err_handler.log_critical(ConfigOptions, MpiConfig)
     err_handler.check_program_status(ConfigOptions, MpiConfig)
 
-   
+
     ## Convert local precip back to a rate (mm/s)
     try:
-        ratioRainGrid[indValid] = ratioRainGrid[indValid]/3600 
+        ratioRainGrid[indValid] = ratioRainGrid[indValid]/3600
 
     except:
         ConfigOptions.errMsg = "Unable to convert temporary precip rate from mm to mm/s."
         err_handler.log_critical(ConfigOptions, MpiConfig)
     err_handler.check_program_status(ConfigOptions, MpiConfig)
-    input_forcings.final_forcings[3, :, :] = ratioRainGrid 
+    input_forcings.final_forcings[3, :, :] = ratioRainGrid
 
     # Reset variables for memory efficiency
     idDenom = None

--- a/core/geoMod.py
+++ b/core/geoMod.py
@@ -1,9 +1,12 @@
 import math
 
-import ESMF
-import numpy as np
 from netCDF4 import Dataset
+import numpy as np
 
+try:
+    import ESMF
+except ImportError:
+    import esmpy as ESMF
 
 class GeoMetaWrfHydro:
     """
@@ -37,7 +40,7 @@ class GeoMetaWrfHydro:
         self.y_coord_atts = None
         self.y_coords = None
         self.spatial_global_atts = None
-        
+
     def get_processor_bounds(self):
         """
         Calculate the local grid boundaries for this processor.

--- a/core/regrid.py
+++ b/core/regrid.py
@@ -8,7 +8,11 @@ import sys
 import traceback
 import time
 
-import ESMF
+try:
+    import ESMF
+except ImportError:
+    import esmpy as ESMF
+
 import numpy as np
 import numpy.ma as ma
 
@@ -1462,7 +1466,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         tmp_hr_current = input_forcings.fcst_hour2
                         diff_tmp = tmp_hr_current % 6 if tmp_hr_current % 6 > 0 else 6
                         tmp_hr_previous = tmp_hr_current - diff_tmp
-                  
+
 
                     else:
                         tmp_hr_previous = input_forcings.fcst_hour1

--- a/genForcing.py
+++ b/genForcing.py
@@ -1,8 +1,6 @@
 import argparse
 import os
 
-import ESMF
-
 from core import config
 from core import err_handler
 from core import forcingInputMod
@@ -67,8 +65,6 @@ def main():
         mpi_meta.initialize_comm(job_meta)
     except:
         err_handler.err_out_screen(job_meta.errMsg)
-
-    # ESMF.Manager(debug=True)
 
     # Initialize our WRF-Hydro geospatial object, which contains
     # information about the modeling domain, local processor


### PR DESCRIPTION
* It was found on WCOSS2 that netCDF4 needed to be loaded _before_ ESMF. This reorders those imports where appropriate.

* Newer ESMF versions are now imported as `esmpy`, so code was added to support both old and new names